### PR TITLE
Issue #113: String conversion for Point, Thickness, etc. with space separator

### DIFF
--- a/src/Primitives/CornerRadius.ts
+++ b/src/Primitives/CornerRadius.ts
@@ -10,7 +10,7 @@ nullstone.registerTypeConverter(CornerRadius, (val: any): CornerRadius => {
         return new CornerRadius();
     if (typeof val === "number")
         return new CornerRadius(val, val, val, val);
-    var tokens = val.toString().split(",");
+    var tokens = val.toString().split(/[ ,]/);
     var topLeft, topRight, bottomRight, bottomLeft;
     if (tokens.length === 1) {
         topLeft = topRight = bottomRight = bottomLeft = parseFloat(tokens[0]);

--- a/src/Primitives/CornerRadius.ts
+++ b/src/Primitives/CornerRadius.ts
@@ -10,7 +10,7 @@ nullstone.registerTypeConverter(CornerRadius, (val: any): CornerRadius => {
         return new CornerRadius();
     if (typeof val === "number")
         return new CornerRadius(val, val, val, val);
-    var tokens = val.toString().split(/[ ,]/);
+    var tokens = val.toString().split(/ *,? */);
     var topLeft, topRight, bottomRight, bottomLeft;
     if (tokens.length === 1) {
         topLeft = topRight = bottomRight = bottomLeft = parseFloat(tokens[0]);

--- a/src/Primitives/Point.ts
+++ b/src/Primitives/Point.ts
@@ -18,7 +18,7 @@ nullstone.registerTypeConverter(Point, (val: any): Point => {
         return <Point>val;
     if (val instanceof minerva.Point)
         return new Point(val.x, val.y);
-    var tokens = val.toString().split(/[ ,]/);
+    var tokens = val.toString().split(/ *,? */);
     if (tokens.length === 2) {
         var x = parseFloat(tokens[0]);
         var y = parseFloat(tokens[1]);

--- a/src/Primitives/Point.ts
+++ b/src/Primitives/Point.ts
@@ -18,7 +18,7 @@ nullstone.registerTypeConverter(Point, (val: any): Point => {
         return <Point>val;
     if (val instanceof minerva.Point)
         return new Point(val.x, val.y);
-    var tokens = val.toString().split(",");
+    var tokens = val.toString().split(/[ ,]/);
     if (tokens.length === 2) {
         var x = parseFloat(tokens[0]);
         var y = parseFloat(tokens[1]);

--- a/src/Primitives/Rect.ts
+++ b/src/Primitives/Rect.ts
@@ -11,7 +11,7 @@ nullstone.registerTypeConverter(Rect, (val: any): any => {
     if (val instanceof Rect)
         return val;
 
-    var tokens = val.toString().split(",");
+    var tokens = val.toString().split(/[ ,]/);
     if (tokens.length === 4) {
         return new Rect(parseFloat(tokens[0]), parseFloat(tokens[1]), parseFloat(tokens[2]), parseFloat(tokens[3]));
     }

--- a/src/Primitives/Rect.ts
+++ b/src/Primitives/Rect.ts
@@ -11,7 +11,7 @@ nullstone.registerTypeConverter(Rect, (val: any): any => {
     if (val instanceof Rect)
         return val;
 
-    var tokens = val.toString().split(/[ ,]/);
+    var tokens = val.toString().split(/ *,? */);
     if (tokens.length === 4) {
         return new Rect(parseFloat(tokens[0]), parseFloat(tokens[1]), parseFloat(tokens[2]), parseFloat(tokens[3]));
     }

--- a/src/Primitives/Size.ts
+++ b/src/Primitives/Size.ts
@@ -12,7 +12,7 @@ nullstone.registerTypeConverter(Size, (val: any): Size => {
         return <Size>val;
     if (val instanceof minerva.Size)
         return new Size(val.width, val.height);
-    var tokens = val.toString().split(",");
+    var tokens = val.toString().split(/[ ,]/);
     if (tokens.length === 2) {
         var w = parseFloat(tokens[0]);
         var h = parseFloat(tokens[1]);

--- a/src/Primitives/Size.ts
+++ b/src/Primitives/Size.ts
@@ -12,7 +12,7 @@ nullstone.registerTypeConverter(Size, (val: any): Size => {
         return <Size>val;
     if (val instanceof minerva.Size)
         return new Size(val.width, val.height);
-    var tokens = val.toString().split(/[ ,]/);
+    var tokens = val.toString().split(/ *,? */);
     if (tokens.length === 2) {
         var w = parseFloat(tokens[0]);
         var h = parseFloat(tokens[1]);

--- a/src/Primitives/Thickness.ts
+++ b/src/Primitives/Thickness.ts
@@ -22,7 +22,7 @@ nullstone.registerTypeConverter(Thickness, (val: any): Thickness => {
         var t = <Thickness>val;
         return new Thickness(t.left, t.top, t.right, t.bottom);
     }
-    var tokens = val.toString().split(",");
+    var tokens = val.toString().split(/[ ,]/);
     var left, top, right, bottom;
     if (tokens.length === 1) {
         left = top = right = bottom = parseFloat(tokens[0]);

--- a/src/Primitives/Thickness.ts
+++ b/src/Primitives/Thickness.ts
@@ -22,7 +22,7 @@ nullstone.registerTypeConverter(Thickness, (val: any): Thickness => {
         var t = <Thickness>val;
         return new Thickness(t.left, t.top, t.right, t.bottom);
     }
-    var tokens = val.toString().split(/[ ,]/);
+    var tokens = val.toString().split(/ *,? */);
     var left, top, right, bottom;
     if (tokens.length === 1) {
         left = top = right = bottom = parseFloat(tokens[0]);

--- a/test/tests/TypeConverterTests.ts
+++ b/test/tests/TypeConverterTests.ts
@@ -71,6 +71,12 @@ export function load() {
         strictEqual(t.top, 2, "Full (Top)");
         strictEqual(t.right, 4, "Full (Right)");
         strictEqual(t.bottom, 6, "Full (Bottom)");
+
+        t = <Thickness>nullstone.convertAnyToType("0 2 4 6", Thickness);
+        strictEqual(t.left, 0, "Full (Left)");
+        strictEqual(t.top, 2, "Full (Top)");
+        strictEqual(t.right, 4, "Full (Right)");
+        strictEqual(t.bottom, 6, "Full (Bottom)");
     });
 
     test("CornerRadius", () => {
@@ -91,12 +97,52 @@ export function load() {
         strictEqual(cr.topRight, 2, "Full (TopRight)");
         strictEqual(cr.bottomRight, 4, "Full (BottomRight)");
         strictEqual(cr.bottomLeft, 6, "Full (BottomLeft)");
+
+        cr = <CornerRadius>nullstone.convertAnyToType("0  2  4  6", CornerRadius);
+        strictEqual(cr.topLeft, 0, "Full (TopLeft)");
+        strictEqual(cr.topRight, 2, "Full (TopRight)");
+        strictEqual(cr.bottomRight, 4, "Full (BottomRight)");
+        strictEqual(cr.bottomLeft, 6, "Full (BottomLeft)");
     });
 
     test("Point", () => {
         var p = <Point>nullstone.convertAnyToType("1, 3", Point);
         strictEqual(p.x, 1, "Point.X");
         strictEqual(p.y, 3, "Point.Y");
+
+        var p = <Point>nullstone.convertAnyToType("1 3", Point);
+        strictEqual(p.x, 1, "Point.X");
+        strictEqual(p.y, 3, "Point.Y");
+
+        var p = <Point>nullstone.convertAnyToType("1  3", Point);
+        strictEqual(p.x, 1, "Point.X");
+        strictEqual(p.y, 3, "Point.Y");
+    });
+
+    test("Rect", () => {
+        var r = <Rect>nullstone.convertAnyToType("1,3,5,7", Rect);
+        strictEqual(r.x, 1, "Rect.X");
+        strictEqual(r.y, 3, "Rect.Y");
+        strictEqual(r.width, 5, "Rect.X");
+        strictEqual(r.height, 7, "Rect.Y");
+
+        var r = <Rect>nullstone.convertAnyToType("1, 3, 5, 7", Rect);
+        strictEqual(r.x, 1, "Rect.X");
+        strictEqual(r.y, 3, "Rect.Y");
+        strictEqual(r.width, 5, "Rect.X");
+        strictEqual(r.height, 7, "Rect.Y");
+
+        var r = <Rect>nullstone.convertAnyToType("1 3 5 7", Rect);
+        strictEqual(r.x, 1, "Rect.X");
+        strictEqual(r.y, 3, "Rect.Y");
+        strictEqual(r.width, 5, "Rect.X");
+        strictEqual(r.height, 7, "Rect.Y");
+
+        var r = <Rect>nullstone.convertAnyToType("1  3  5  7", Rect);
+        strictEqual(r.x, 1, "Rect.X");
+        strictEqual(r.y, 3, "Rect.Y");
+        strictEqual(r.width, 5, "Rect.X");
+        strictEqual(r.height, 7, "Rect.Y");
     });
 
     test("Length", () => {


### PR DESCRIPTION
Silverlight accepts both space and comma as separators when specifying
multiple numeric values in a single string.