### PR TITLE
Add unit test for Matrix to raw mapping

### DIFF
--- a/src/Media/Matrix.ts
+++ b/src/Media/Matrix.ts
@@ -17,14 +17,14 @@ module Fayde.Media {
         get M12() { return this._Raw[1]; }
         set M12(val: number) { this._Raw[1] = val; this._OnChanged(); }
 
-        get M21() { return this._Raw[3]; }
-        set M21(val: number) { this._Raw[3] = val; this._OnChanged(); }
+        get M21() { return this._Raw[2]; }
+        set M21(val: number) { this._Raw[2] = val; this._OnChanged(); }
 
-        get M22() { return this._Raw[4]; }
-        set M22(val: number) { this._Raw[4] = val; this._OnChanged(); }
+        get M22() { return this._Raw[3]; }
+        set M22(val: number) { this._Raw[3] = val; this._OnChanged(); }
 
-        get OffsetX() { return this._Raw[2]; }
-        set OffsetX(val: number) { this._Raw[2] = val; this._OnChanged(); }
+        get OffsetX() { return this._Raw[4]; }
+        set OffsetX(val: number) { this._Raw[4] = val; this._OnChanged(); }
 
         get OffsetY() { return this._Raw[5]; }
         set OffsetY(val: number) { this._Raw[5] = val; this._OnChanged(); }

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -1,5 +1,6 @@
 module runner {
     var testModules = [
+        ".build/tests/MatrixTests",
         ".build/tests/PrimitivesTests",
         ".build/tests/FormatTests",
         ".build/tests/TypeConverterTests",

--- a/test/tests/MatrixTests.ts
+++ b/test/tests/MatrixTests.ts
@@ -1,0 +1,20 @@
+export function load() {
+    QUnit.module("Matrix Tests");
+
+    test("Matrix to Raw mapping", () => {
+        var m: Fayde.Media.Matrix;
+
+	m = new Fayde.Media.Matrix();
+	m.M11 = 0;
+	m.M12 = 1;
+	m.M21 = 2;
+	m.M22 = 3;
+	m.OffsetX = 4;
+	m.OffsetY = 5;
+
+	for (var i=0; i<6; i++)
+	{
+	    strictEqual(m._Raw[i], i, "Matrix[" + i + "]");
+	}
+    });
+}


### PR DESCRIPTION
Tests for a fixed bug where Mxy and OffsetXY were mapped to the wrong
locations in the raw matrix.