### PR TITLE
Trying to wire views by viewmodel type, not working yet.

### DIFF
--- a/testsite/ViewTemplates/ViewTemplates.fap
+++ b/testsite/ViewTemplates/ViewTemplates.fap
@@ -1,0 +1,39 @@
+﻿<Application xmlns="http://schemas.wsick.com/fayde" xmlns:x="http://schemas.wsick.com/fayde/x" xmlns:local="ViewTemplates" ThemeName="Metro">
+    <StackPanel>
+        <StackPanel.DataContext>
+            <local:VtViewModel />
+        </StackPanel.DataContext>
+
+        <TextBlock Text="This sample demonstrates autowiring views to viewmodels by their class type." Margin="10"/>
+
+        <TextBlock Text="Manual list item template assignment:" Margin="10"/>
+        <ListBox ItemsSource="{Binding ListItems}" Background="Silver">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding DisplayName}" FontWeight="Bold" />
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <StackPanel>
+            <StackPanel.Resources>
+                <DataTemplate DataType="local:VtItemViewModel">
+                    <TextBlock Text="{Binding DisplayName}" FontWeight="Bold" />
+                </DataTemplate>
+            </StackPanel.Resources>
+            <TextBlock Text="Automatic template selection, setting template body:" Margin="10"/>
+            <ListBox ItemsSource="{Binding ListItems}" Background="Silver" />
+        </StackPanel>
+
+        <StackPanel>
+            <StackPanel.Resources>
+                <DataTemplate DataType="local:VtItemViewModel">
+                    <ContentControl ContentUri="ViewTemplates/VtItemView.fayde" />
+                </DataTemplate>
+            </StackPanel.Resources>
+            <TextBlock Text="Automatic template selection, setting template URI:" Margin="10"/>
+            <ListBox ItemsSource="{Binding ListItems}" Background="Silver" />
+        </StackPanel>
+
+    </StackPanel>
+</Application>

--- a/testsite/ViewTemplates/VtItemView.fayde
+++ b/testsite/ViewTemplates/VtItemView.fayde
@@ -1,0 +1,3 @@
+﻿<Grid xmlns="http://schemas.wsick.com/fayde" xmlns:x="http://schemas.wsick.com/fayde/x">
+    <TextBlock Text="{Binding DisplayName}" FontWeight="Bold"/>
+</Grid>

--- a/testsite/ViewTemplates/VtItemViewModel.ts
+++ b/testsite/ViewTemplates/VtItemViewModel.ts
@@ -1,0 +1,11 @@
+class VtItemViewModel extends Fayde.MVVM.ViewModelBase
+{
+    DisplayName:string;
+
+    constructor(displayname:string)
+    {
+        super();
+        this.DisplayName = displayname;
+    }
+}
+export = VtItemViewModel;

--- a/testsite/ViewTemplates/VtViewModel.ts
+++ b/testsite/ViewTemplates/VtViewModel.ts
@@ -1,0 +1,15 @@
+import VtItemViewModel = require("./VtItemViewModel");
+
+class VtViewModel extends Fayde.MVVM.ViewModelBase
+{
+    ListItems = new Fayde.Collections.ObservableCollection<VtItemViewModel>();
+
+    constructor()
+    {
+        super();
+        this.ListItems.Add(new VtItemViewModel("One"));
+        this.ListItems.Add(new VtItemViewModel("Two"));
+        this.ListItems.Add(new VtItemViewModel("Three"));
+    }
+}
+export = VtViewModel;

--- a/testsite/index.html
+++ b/testsite/index.html
@@ -91,7 +91,8 @@
         'Validation/notifydataerrorinfo.fap',
         'Validation/dataerrorinfo.fap',
         'Validation/exception.fap',
-        'Videos/mediacontrol.fap'
+        'Videos/mediacontrol.fap',
+        'ViewTemplates/ViewTemplates.fap'
     ];
     for (var i = 0; i < tests.length; i++) {
         var a = document.createElement('a');


### PR DESCRIPTION
Trying view templates binding by data type, as advised in gitter chat. Might be that syntax is incorrect, might be that wiring is not working as expected.

Note that this syntax uses specifying the type as just the type reference, yet the Big WPF requires the `{x:type} syntax, though it isn't working either way actually.
Also, if possible, I'd love to have both syntaxes operational.