### PR TITLE
Null argument exception in mat3.multiply

### DIFF
--- a/src/Media/Transforms.ts
+++ b/src/Media/Transforms.ts
@@ -124,7 +124,8 @@ module Fayde.Media {
             var enumerator = this.Children.getEnumerator();
             var cur = mat3.identity();
             while (enumerator.moveNext()) {
-                mat3.multiply(cur, (<Transform>enumerator.current).Value._Raw, cur); //cur = cur * child
+                if (cur && (<Transform>enumerator.current).Value._Raw)
+                    mat3.multiply(cur, (<Transform>enumerator.current).Value._Raw, cur); //cur = cur * child
             }
             return cur;
         }


### PR DESCRIPTION
In some cases enumerator.current.Value._Raw can be null. Calling mat3.multiply produces an error and rendering fails.