### PR TITLE
Added Touch Event Handlers.

### DIFF
--- a/src/Controls/ComboBox.ts
+++ b/src/Controls/ComboBox.ts
@@ -161,6 +161,26 @@ module Fayde.Controls {
             super.OnMouseLeave(e);
             this.UpdateVisualState(true);
         }
+        
+        OnTouchMove(e: Input.TouchEventArgs){
+			super.OnTouchMove(e);
+            this.UpdateVisualState(true);
+		}
+		
+		OnTouchDown(e: Input.TouchEventArgs){
+			super.OnTouchDown(e);
+            if (!e.Handled) {
+                e.Handled = true;
+                this.SetValueInternal(ComboBox.IsSelectionActiveProperty, true);
+                this.IsDropDownOpen = !this.IsDropDownOpen;
+            }
+		}
+		
+		OnTouchLeave(e: Input.TouchEventArgs){
+			super.OnTouchLeave(e);
+            this.UpdateVisualState(true);
+		}
+		
         OnKeyDown(e: Input.KeyEventArgs) {
             super.OnKeyDown(e);
             if (e.Handled)


### PR DESCRIPTION
Missing touch event handlers were causing the entire UI to become unresponsive after interacting with a combo box.