### PR TITLE
Fixed scroll position OnTouchMove.

### DIFF
--- a/src/Controls/ScrollViewer.ts
+++ b/src/Controls/ScrollViewer.ts
@@ -241,8 +241,8 @@ module Fayde.Controls {
             var origin = this._TouchOrigin;
             delta.x = pos.x - origin.x;
             delta.y = pos.y - origin.y;
-            this.ScrollToHorizontalOffset(delta.x);
-            this.ScrollToVerticalOffset(delta.y);
+            this.ScrollToHorizontalOffset(this._TouchInitialOffset.x + delta.x);
+            this.ScrollToVerticalOffset(this._TouchInitialOffset.y + delta.y);
         }
 
         OnKeyDown(e: Input.KeyEventArgs) {


### PR DESCRIPTION
Setting the ScrollViewer's position to only the delta when a touchmove event occurs is not correct. The delta needs to be added to the current scroll offset.